### PR TITLE
Fix missing Colors export

### DIFF
--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -31,3 +31,8 @@ export const darkColors = {
   shadow: 'rgba(255, 255, 255, 0.1)',
   info: '#5ac8fa',
 };
+
+export const Colors = {
+  light: lightColors,
+  dark: darkColors,
+} as const;


### PR DESCRIPTION
## Summary
- export combined `Colors` object from the theme

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852635fd72c8323864685976fa900af