### PR TITLE
Fix duplicate dropdown reset

### DIFF
--- a/src/screens/AddItemScreen.tsx
+++ b/src/screens/AddItemScreen.tsx
@@ -87,7 +87,7 @@ export default function AddItemScreen() {
     setImage(null); 
     setShowErrors(false);
     setShowLocationDropdown(false);
-    setShowLocationDropdown(false)
+    setShowCategoryDropdown(false);
     router.replace('/');
   };
 


### PR DESCRIPTION
## Summary
- remove repeated state reset in `handleAdd`
- reset the category dropdown too

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852646a4e808323800f9ad420422c73