### PR TITLE
Fix AddItemScreen permissions

### DIFF
--- a/src/screens/AddItemScreen.tsx
+++ b/src/screens/AddItemScreen.tsx
@@ -65,10 +65,20 @@ export default function AddItemScreen() {
       { text: 'Cancel', style: 'cancel' },
     ]);
   const openCamera = async () => {
+    const permission = await ImagePicker.requestCameraPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission required', 'Camera access is needed to take photos.');
+      return;
+    }
     const result = await ImagePicker.launchCameraAsync({ quality: 0.7, allowsEditing: true });
     if (!result.canceled) setImage(result.assets[0].uri);
   };
   const openGallery = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission required', 'Media library access is needed to select photos.');
+      return;
+    }
     const result = await ImagePicker.launchImageLibraryAsync({ quality: 0.7, allowsEditing: true });
     if (!result.canceled) setImage(result.assets[0].uri);
   };


### PR DESCRIPTION
## Summary
- request camera & media library permissions before launching pickers

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685267e613c483238c5647a358e107f1